### PR TITLE
docs(faq): remove reference to relaxed queue limit

### DIFF
--- a/FAQs.md
+++ b/FAQs.md
@@ -151,7 +151,7 @@ A: You can have 3 jobs going at once (of any kind, 2x2, upscale etc). If you sub
 
 **Q: How many concurrent jobs can I run? How many can I queue?**
 
-A: You can generate 3 images at once. If you start more jobs you'll get a message saying "your job will start shortly." You can start 10 jobs before your queue is full. If you are in relax mode this decreases to 2 concurrent images at once.
+A: You can generate 3 images at once. If you start more jobs you'll get a message saying "your job will start shortly." You can start 10 jobs before your queue is full.
 
 
 


### PR DESCRIPTION
It seems the relaxed queue limit may have been changed to 3
for consistency with the fast queue. Or these are both sharing
the same concurrency limit between them.

This removes the reference to the relaxed jobs being different.
Seems clear enough now that the 3 limit is across both relaxed
and fast queues since no mention is made to either.

---

Let's just have this verified before merging.
If there is a fast/relaxed concurrency separation then this may need to be updated more.