### PR TITLE
imagine-parameters: Clean up prompts and fix images

### DIFF
--- a/imagine-parameters.md
+++ b/imagine-parameters.md
@@ -6,14 +6,14 @@ description: An illustrated Guide to /imagine parameters
 
 ### Basic Structure
 
-Parameters options that change how the images generate. A full `/imagine` command might contain several things, like an image URL, image weights, algorithm versions, and other switches.\
-\
+Parameters options that change how the images generate. A full `/imagine` command might contain several things, like an image URL, image weights, algorithm versions, and other switches.
+
 `/imagine` parameters should follow the below order:
 
 ![/imagine prompt: https://example/tulip.jpg  a field of tulips in the style of Mary Blair --no farms --iw .5 --ar 3:2"](.gitbook/assets/ImagineStructure.jpg)
 
-"Switches" in this context means controls passed to the bot using a "--" parameter. For instance, the command `/imagine hi there --w 448` has a text prompt, and a parameter for the width, using the "--w" instruction.\
-\\
+"Switches" in this context means controls passed to the bot using a "--" parameter. For instance, the command `/imagine hi there --w 448` has a text prompt, and a parameter for the width, using the "--w" instruction.
+
 
 ### Sizes
 
@@ -25,21 +25,21 @@ Parameters options that change how the images generate. A full `/imagine` comman
 
 `--w` and `--h` values above 512 are unstable and may cause errors.
 
-<img src=".gitbook/assets/MJ_Imagine.png" alt="" data-size="original"> \*\*\*\*
+<img src=".gitbook/assets/MJ_Imagine.png" alt="" data-size="original">
 
 **/imagine:** `prompt`**`vibrant california poppies`**
 
-`![](.gitbook/assets/MJ--w.png)`
+![](.gitbook/assets/MJ--w.png)
 
 **/imagine:**`prompt`**`vibrant california poppies --w 448`**
-
-**\`\`**
 
 `--aspect` or `--ar` Sets a desired aspect ratio, instead of manually setting height and width with `--h` and `--w`.
 
 Try `--ar 16:9` for example, to get a 9:16 aspect ratio (\~256x448).
 
-![](.gitbook/assets/mj--ar.png)`prompt`**`vibrant california poppies --ar 9:16`**
+![](.gitbook/assets/mj--ar.png)
+
+**/imagine:**`prompt`**`vibrant california poppies --ar 9:16`**
 
 Also see [Understanding Image Sizes](resource-links/understanding-image-size.md).
 
@@ -52,8 +52,6 @@ These "shortcuts" are command that do the same as the forms following the ":" in
 It would be the same as typing the longer form:
 
 **/imagine:** `prompt`**`vibrant california poppies`**`--w 1920 --h 1024 --hd`
-
-\`\`
 
 Shortcut equivalences:
 
@@ -77,29 +75,37 @@ Shortcut equivalences:
 
 #### Version 1
 
-`--version 1` or `--v 1` uses the original Midjourney algorithm (more abstract, sometimes better for macro or textures). `--v 1` corresponds to the <img src=".gitbook/assets/MJ_v1_btn.png" alt="" data-size="line">button in `/settings.`
+`--version 1` or `--v 1` uses the original Midjourney algorithm (more abstract, sometimes better for macro or textures). `--v 1` corresponds to the <img src=".gitbook/assets/MJ_v1_btn.png" alt="" data-size="line">button in `/settings`.
 
-\`\`![](<.gitbook/assets/image (10).png>) prompt: **`vibrant california poppies` --version 1**
+![](<.gitbook/assets/image (10).png>)
+
+**/imagine:** `prompt`**`vibrant california poppies --version 1`**
 
 #### Version **2**
 
 `--version 2` or `--v 2` uses the original Midjourney algorithm in use before July 25th, 2022.\
-`--v 2` corresponds to the <img src=".gitbook/assets/MJ_v2_btn.png" alt="" data-size="line">button in `/settings.`
+`--v 2` corresponds to the <img src=".gitbook/assets/MJ_v2_btn.png" alt="" data-size="line">button in `/settings`.
 
-![](.gitbook/assets/mj--v2.png) prompt: **`vibrant california poppies` --v 2**
+![](.gitbook/assets/mj--v2.png)
+
+**/imagine:** `prompt`**`vibrant california poppies --v 2`**
 
 #### Version **3**
 
 `--version 3` or `--v 3` uses the current default Midjourney algorithm.\
-`--v 3` corresponds to the <img src=".gitbook/assets/MJ_v3_btn.png" alt="" data-size="line"> button in `/settings.`
+`--v 3` corresponds to the <img src=".gitbook/assets/MJ_v3_btn.png" alt="" data-size="line"> button in `/settings`.
 
-\`\`![](.gitbook/assets/mj--v3.png) prompt: **`vibrant california poppies --v 3`**
+![](.gitbook/assets/mj--v3.png)
+
+**/imagine:** `prompt`**`vibrant california poppies --v 3`**
 
 #### High Definition
 
 `--hd` Uses a different algorithm that’s potentially better for larger images, but with less consistent compositions.
 
-![](.gitbook/assets/mj--hd.png)prompt: **`vibrant california poppies --hd`**
+![](.gitbook/assets/mj--hd.png)
+
+**/imagine:** `prompt`**`vibrant california poppies --hd`**
 
 ### Prompt Modifiers
 
@@ -107,7 +113,9 @@ Shortcut equivalences:
 
 `--no` Negative prompting (e.g., `--no plants` would try to remove plants). This is like giving it a weight of -0.5.
 
-![](<.gitbook/assets/mj--no (1).png>) prompt: \*\*`vibrant california poppies --no grass` \*\*
+![](<.gitbook/assets/mj--no (1).png>)
+
+**/imagine:** `prompt`**`vibrant california poppies --no grass`**
 
 ### Detail Modifiers
 
@@ -115,7 +123,9 @@ Shortcut equivalences:
 
 `--stop` Stop the generation at an earlier percentage. Must be between 10-100.
 
-![](<.gitbook/assets/image (1).png>) prompt: **`vibrant california poppies --stop 50`**
+![](<.gitbook/assets/image (1).png>)
+
+**/imagine:** `prompt`**`vibrant california poppies --stop 50`**
 
 #### --Uplight
 
@@ -135,11 +145,11 @@ A seed number generate the random starting noise used in the begining of image g
 
 ![](.gitbook/assets/MJ\_Imagine.png) ![](.gitbook/assets/mj\_seed.png)
 
-`/imagine prompt: an abstract field of flowers` run twice without a seed.
+**/imagine:** `prompt`**`an abstract field of flowers`** run twice without a seed.
 
 ![](.gitbook/assets/MJ\_Imagine.png) ![](.gitbook/assets/mj\_seedtwice.png)
 
-`prompt:`**`vibrant california poppies`**` `` ``--seed 0987 ` run twice.
+**/imagine:** `prompt`**`vibrant california poppies --seed 0987`** run twice.
 
 #### --Sameseed
 
@@ -147,7 +157,7 @@ A seed number generate the random starting noise used in the begining of image g
 
 ![](.gitbook/assets/mj\_sameseed.png)
 
-`prompt:`**`vibrant california poppies`**` `` ``--sameseed 0987 `
+**/imagine:** `prompt`**`vibrant california poppies --sameseed 0987`**
 
 ### --Stylize
 
@@ -158,53 +168,47 @@ See the [User Manual](user-manual.md#stylize-values) for more detailed informati
 ![](.gitbook/assets/mj--s1250.png)
 
 `--s 1250` Good for when you want it to be 'less strict' but still 'pretty' (this is probably recommended for skilled users).\
-`--s 1250` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleLow.png" alt="" data-size="line"> button in `/settings.`
+`--s 1250` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleLow.png" alt="" data-size="line"> button in `/settings`.
 
-\`\`![](.gitbook/assets/MJ--s2500.png)
+![](.gitbook/assets/MJ--s2500.png)
 
 `--s 2500` The default style level.\
-`--s 2500` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleMed (1).png" alt="" data-size="line"> button in `/settings.`
+`--s 2500` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleMed (1).png" alt="" data-size="line"> button in `/settings`.
 
-`![](.gitbook/assets/mj--5000.png)`
+![](.gitbook/assets/mj--5000.png)
 
-`--s 5000` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleHigh.png" alt="" data-size="line"> button in `/settings.`
+`--s 5000` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleHigh.png" alt="" data-size="line"> button in `/settings`.
 
-\`\`
-
-`![](.gitbook/assets/mj--s20000.png)`
+![](.gitbook/assets/mj--s20000.png)
 
 `--s 20000` If you want it to 'take over' and start drifting from your text, but not go crazy.\
-`--s 20000` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleVeryHigh.png" alt="" data-size="line"> button in `/settings.`
+`--s 20000` corresponds to the <img src=".gitbook/assets/MJ_v1_StyleVeryHigh.png" alt="" data-size="line"> button in `/settings`.
 
 ### --Quality
 
 `--quality <number>` , or `--q <number>` Sets how much rendering quality time you want to spend. Default number is 1. Higher values take more time and cost more\
 See the [User Manual](user-manual.md#quality-values) for more detailed information.
 
-\`\`
+![](.gitbook/assets/mj--q05.png)
 
-`![](.gitbook/assets/mj--q05.png)`
+**/imagine:** `prompt`**`vibrant california poppies --q .5`**
 
 `--q .5` Rougher results, 2x faster / cheaper.\
-`prompt:`**`vibrant california poppies --q .5`**\
-**\`\`**`--q .5` corresponds to the <img src=".gitbook/assets/MJ_QualHalf.png" alt="" data-size="line"> button in `/settings.`
+`--q .5` corresponds to the <img src=".gitbook/assets/MJ_QualHalf.png" alt="" data-size="line"> button in `/settings`.
 
-\`\`
+![](.gitbook/assets/MJ\_Imagine.png)
 
-**`**![](.gitbook/assets/MJ\_Imagine.png)**`**
+**/imagine:** `prompt`**`vibrant california poppies --q 1`**
 
 `--q 1` The **default value**, you do not need to specify it.\
-**``**`prompt:`**`vibrant california poppies`**\ **``**`--q 1` corresponds to the <img src=".gitbook/assets/MJ_Qual1.png" alt="" data-size="line"> button in `/settings.`
+`--q 1` corresponds to the <img src=".gitbook/assets/MJ_Qual1.png" alt="" data-size="line"> button in `/settings`.
 
-\`\`
+![](.gitbook/assets/mj--q2.png)
 
-`![](.gitbook/assets/mj--q2.png)`
+**/imagine:** `prompt`**`vibrant california poppies --q 2`**
 
-`--q 2` More detailed results, 2x slower / more expensive\
-**``**`prompt:`**`vibrant california poppies --q 2`**\
-**``**`--q 2` corresponds to the <img src=".gitbook/assets/MJ_Qual2X.png" alt="" data-size="line"> button in `/settings.`
-
-### \`\`
+`--q 2` More detailed results, 2x slower / more expensive.\
+`--q 2` corresponds to the <img src=".gitbook/assets/MJ_Qual2X.png" alt="" data-size="line"> button in `/settings`.
 
 ### `Progress Videos`
 
@@ -234,11 +238,15 @@ Image prompt use with no `--iw` parameter, `--iw .5` `--iw 1` `--iw 2` and `--iw
 
 **From left to right:**
 
-* ` prompt`` `` `**`https://dots.jpg vibrant california poppies`** (default image weight is .25)
-* ` prompt`` `` `**`https://dots.jpg vibrant california poppies --iw .5`**
-* ` prompt`` `` `**`https://dots.jpg vibrant california poppies --iw 1`**
-* ` prompt`` `` `**`https://dots.jpg vibrant california poppies --iw 2`**
-* ` prompt`` `` `**`https://dots.jpg vibrant california poppies --iw 5`**
+* **/imagine:** `prompt`**`https://dots.jpg vibrant california poppies`** (default image weight is .25)
+
+* **/imagine:** `prompt`**`https://dots.jpg vibrant california poppies --iw .5`**
+
+* **/imagine:** `prompt`**`https://dots.jpg vibrant california poppies --iw 1`**
+
+* **/imagine:** `prompt`**`https://dots.jpg vibrant california poppies --iw 2`**
+
+* **/imagine:** `prompt`**`https://dots.jpg vibrant california poppies --iw 5`**
 
 ### Settings
 


### PR DESCRIPTION
It looks like some wrong formatting snuck into the page. I've tried to resolve that here.

- Remove leftover punctuation.
- Fix a few images which became inline text.
- Consistent prompt format with **/imagine**.
- Consistently put the prompts under the example images.
- Consistently put the dot after `/settings`.